### PR TITLE
Update lab code and instructions to reflect azd 1RP and compose beta changes

### DIFF
--- a/Lab-Instructions/0.getting-started.md
+++ b/Lab-Instructions/0.getting-started.md
@@ -9,7 +9,7 @@ This lab is designed to teach you how to add AI features, like AI Search and AI 
 - GitHub Copilot for Azure extension
 - GitHub Copilot License
 - Azure Account
-- Azure Developer CLI
+- Azure Developer CLI (v1.17.0 or later)
 - Docker Desktop
 
 ## Prerequisite Knowledge 

--- a/Lab-Instructions/1.exercise-deploy-app.md
+++ b/Lab-Instructions/1.exercise-deploy-app.md
@@ -20,7 +20,6 @@ Once you complete this exercise, you will have your application deployed to Azur
 
 ## Instructions
 1. In a VS Code terminal, make sure you are in the **/src** directory. 
-1. Run `azd config set alpha.compose on` to enable the feature since azd Compose is an alpha feature.
 1. Run `azd init` to initialize the project.
     * Select "Use code in the current directory".
     * Select "Confirm and continue initializing my app".
@@ -66,7 +65,7 @@ Once you complete this exercise, you will have your application deployed to Azur
 At this point, your azure.yaml should look like this:
 
 ``` yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/alpha/azure.yaml.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
 
 name: src
 metadata:
@@ -88,11 +87,10 @@ resources:
 azd Compose uses Bicep. All IaC files are generated in memory.
 
 To get the Bicep code:
-* Run `azd config set alpha.infraSynth on` to enable the feature (infraSynth is also an alpha feature.)
-* Run `azd infra synth` to get the /infra folder and all Bicep files generated under /infra.
+* Run `azd infra gen` to get the /infra folder and all Bicep files generated under /infra.
 
 > [!NOTE]
-> If you run `azd infra synth`, make sure you delete the /infra folder before you proceed with subsequent exercise. Otherwise, every time you add a new resource using `azd add`, you need to run `azd infra synth` to regenerate the Bicep code written on disk.
+> If you run `azd infra gen`, make sure you delete the /infra folder before you proceed with subsequent exercise. Otherwise, every time you add a new resource using `azd add`, you need to run `azd infra gen` to regenerate the Bicep code written on disk.
 
 Questions:
 1. Can you tell us if zone redundancy is enabled for the Azure Container app?

--- a/Lab-Instructions/2.exercise-ai-search.md
+++ b/Lab-Instructions/2.exercise-ai-search.md
@@ -14,7 +14,7 @@ In this module, you are going to run `azd add` to add Azure AI Search, create an
 
 ## Working with azd Compose
 
-[azd Compose](https://aka.ms/azd-compose) is an alpha feature that allows you to progressively add Azure resources. You can run a new command called `azd add` and build up your app in a step-by-step manner as you learn.
+[azd Compose](https://aka.ms/azd-compose) is a beta feature that allows you to progressively add Azure resources. You can run a new command called `azd add` and build up your app in a step-by-step manner as you learn.
 
 ## Instructions
 
@@ -25,7 +25,7 @@ In this module, you are going to run `azd add` to add Azure AI Search, create an
     * Make sure your service uses the newly added resource by typing \<space> to select.
     ![Connect service to search](/Lab-Instructions/Images/2.ConnectServicetoSearch.png)
     * Type "Y" or simply hit \<enter> to accept changes to azure.yaml.  
-1. If the **infra** folder exists, run `azd provision` to provision the newly added resource. **Note**: You see this because you have run `azd infra synth`, delete the **infra** folder and then run `azd provision` or run `azd infra synth` again to re-synthesize the infrastructure before running `azd provision`.
+1. If the **infra** folder exists, run `azd provision` to provision the newly added resource. **Note**: You see this because you have run `azd infra gen`, delete the **infra** folder and then run `azd provision` or run `azd infra gen` again to regenerate the infrastructure before running `azd provision`.
 1. Otherwise, select `Yes` to provision the changes.
 1. Provision can take about 8-10 min. 
 1. While waiting, use @azure to learn more about Azure AI Search.
@@ -88,7 +88,7 @@ Since you didn't change any of the app code, you **do not** need to run `azd dep
 At this point, your azure.yaml should look like this:
 
 ``` yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/alpha/azure.yaml.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
 name: src
 metadata:
   template: azd-init@xxxx

--- a/Lab-Instructions/3.exercise-ai-chat.md
+++ b/Lab-Instructions/3.exercise-ai-chat.md
@@ -92,7 +92,7 @@ Since we added both models, toggle it on to compare and see the difference!
 At this point, your azure.yaml should look like this:
 
 ```yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/alpha/azure.yaml.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
 name: src
 metadata:
   template: azd-init@xxxx

--- a/Lab-Instructions/5.exercise-cost-management.md
+++ b/Lab-Instructions/5.exercise-cost-management.md
@@ -34,3 +34,13 @@ This prompt will scope your request to the selected subscription and query the c
 
 ## Congratulations!
 Congratulations on completing the lab! Throughout this exercise, you transformed a basic Python application into a fully functional system deployed on Azure. You integrated AI Search and AI Chat capabilities, monitored your logs, managed storage accounts efficiently, and researched cost optimization strategies. Well done on mastering these essential skills and enhancing your knowledge in cloud computing and AI technologies!
+
+## Teardown (optional)
+
+To clean up and delete all the Azure resources provisioned during this exercise, you can use the `azd down` command. This step is optional but recommended to avoid incurring unnecessary costs.
+
+1. Make sure you are still in the **/src** folder.
+1. Run the following command:
+   ```bash
+   azd down
+   ```

--- a/Lab-Instructions/vm_requirements.md
+++ b/Lab-Instructions/vm_requirements.md
@@ -16,7 +16,7 @@
     - Bicep
     - **Azure Tools extension pack**
     - **Python**
-- Azure Developer CLI (azd) (`winget install Microsoft.Azd --version 1.16.200` - bug in 1.14)
+- Azure Developer CLI (azd) (`winget install Microsoft.Azd --version 1.17.100`)
 - **Azure CLI (az) (`winget install Microsoft.AzureCLI`)**
 - Python3 (and create venv) (`winget install Python.Python.3.12` unless there a different version is needed)
 - **PowerShell 7.5.1 (`winget install Microsoft.Powershell`)**

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,8 +1,8 @@
 azure-ai-inference==1.0.0b9
-azure-ai-projects==1.0.0b10
-azure-identity==1.22.0
-azure-search-documents==11.6.0b11
-Flask==3.1.0
+azure-ai-projects==1.0.0b11
+azure-identity==1.23.0
+azure-search-documents==11.6.0b12
+Flask==3.1.1
 gunicorn==23.0.0
-openai==1.77.0
+openai==1.82.0
 python-dotenv==1.0.1


### PR DESCRIPTION
- Update lab code to connect to Foundry models using project endpoint (requires latest version of azd to be installed, [v1.17.0](https://github.com/Azure/azure-dev/releases/tag/azure-dev-cli_1.17.0))
- Remove references to alpha features `alpha.compose` and `alpha.infraSynth` as they're now beta and enabled by default
- Rename `azd infra synth` to `azd infra gen` as it was renamed in the latest release
- Add teardown instructions to run `azd down` to clean up provisioned resources

